### PR TITLE
Acme GA-02 on Windows

### DIFF
--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -1,4 +1,5 @@
 # Windows - DINPUT
+8f0e1200000000000000504944564944,Acme,platform:Windows,x:b2,a:b0,b:b1,y:b3,back:b8,start:b9,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,dpup:h0.1,leftshoulder:b4,lefttrigger:b5,rightshoulder:b6,righttrigger:b7,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a3,righty:a2,
 341a3608000000000000504944564944,Afterglow PS3 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,platform:Windows,
 ffff0000000000000000504944564944,GameStop Gamepad,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b2,y:b3,platform:Windows,
 6d0416c2000000000000504944564944,Generic DirectInput Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,platform:Windows,


### PR DESCRIPTION
Windows mappings for the ACME GA-02 gamepad (after installation of drivers). Created with the controllermap utility.

On my computer, it's recognized as "GreenAsia Inc.    USB Joystick     " on Linux and the mappings are the same as on Windows, but they don't match what's already in the database for that GUID. That's why I didn't add it to the Linux section in this pull request.

The controller itself is a clone of the PS controller with two sticks. All its buttons except for the sticks are marked with numbers which match their logical numbers, though starting from 1, not 0. Colors are used instead of the trademarked PS symbols, so X = b0, O = b1, Square = b2, Triangle = b3.

It looks like this, except mine is orange:
http://www.acme.eu/en-us/accessories/gaming-devices/gamepads/acme-ga02-digital-gamepad
