### PR TITLE
Add Twin USB Joystick mapping for Android

### DIFF
--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -174,3 +174,6 @@ d814000000000000cecf000000000000,MC Cthulhu,platform:Mac OS X,leftx:,lefty:,righ
 03000000100800000300000010010000,USB Gamepad,platform:Linux,a:b2,b:b1,x:b3,y:b0,start:b9,back:b8,leftstick:b10,rightstick:b11,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a2,lefttrigger:b4,righttrigger:b5,
 05000000ac0500003232000001000000,VR-BOX,platform:Linux,a:b0,b:b1,x:b2,y:b3,start:b9,back:b8,leftstick:b10,rightstick:b11,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,leftx:a0,lefty:a1,rightx:a3,righty:a2,lefttrigger:b4,righttrigger:b5,
 03000000780000000600000010010000,Microntek USB Joystick,platform:Linux,x:b3,a:b2,b:b1,y:b0,back:b8,start:b9,leftshoulder:b6,lefttrigger:b4,rightshoulder:b7,righttrigger:b5,leftx:a0,lefty:a1,
+
+# Android
+5477696e20555342204a6f7973746963,Twin USB Joystick,platform:Android,x:b23,a:b22,b:b21,y:b20,back:b28,start:b29,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,dpup:h0.1,leftshoulder:b26,lefttrigger:b24,rightshoulder:b27,righttrigger:b25,leftstick:b30,rightstick:b31,leftx:a0,lefty:a1,rightx:a3,righty:a2,


### PR DESCRIPTION
Note that this is the same adapter currently identified in the database as "Twin USB PS2 Adapter" on Linux, although the button numbers differ (for technical reasons specific to Android).

Further note that this mapping's GUID is given in the older format (compatible with SDL v2.0.0-2.0.4).

BTW, it looks like one of Travis' checks fails, since "Android" isn't currently recognized as a proper platform value.