### PR TITLE
check.py: fix initialization of Mapping.__keys

### DIFF
--- a/check.py
+++ b/check.py
@@ -59,7 +59,7 @@ class Mapping:
             "+leftx": "",
             "+lefty": "",
             "+rightx": "",
-            "+righty"
+            "+righty": "",
             "-leftx": "",
             "-lefty": "",
             "-rightx": "",


### PR DESCRIPTION
The code was being interpreted as `"+righty-leftx": ""`