### PR TITLE
Added SDL2 Gamepad Mapper app to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ In Steam's Big Picture mode, configure your joystick. Then look in `[steam_insta
 ### [GNOME Games](https://wiki.gnome.org/Apps/Games)
 GNOME Games allows users to configure their own gamepads. The gamepad file the user generates is located at `~/.var/app/org.gnome.Games/config/libmanette/gamecontrollerdb` when installed from the flatpak. (GNU/Linux)
 
+### [SDL2 Gamepad Mapper](https://gitlab.com/ryochan7/sdl2-gamepad-mapper)
+Open source replacement for older SDL2 Gamepad Tool.
+
 
 ## Resources
 


### PR DESCRIPTION
This is mostly just an excuse to shill. I made an open source equivalent of the SDL2 Gamepad Tool a while ago as a programming exercise. SDL2 Gamepad Tool has not been updated in years and some portions of that app don't quite work right. I figure it is better to have access to an open source app rather than having to rely on a proprietary app anyway.

SDL2 Gamepad Mapper:
https://gitlab.com/ryochan7/sdl2-gamepad-mapper

Latest release page:
https://gitlab.com/ryochan7/sdl2-gamepad-mapper/-/releases/v0.0.3