### PR TITLE
Fix source link in gamecontrollerdb.txt

### DIFF
--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -1,5 +1,5 @@
 # Game Controller DB for SDL in 2.0.16 format
-# Source: https://github.com/gabomdq/SDL_GameControllerDB
+# Source: https://github.com/mdqinc/SDL_GameControllerDB
 
 # Windows
 03000000300f00000a01000000000000,3 In 1 Conversion Box,a:b2,b:b1,back:b9,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b10,lefttrigger:b4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b11,righttrigger:b5,rightx:a3,righty:a2,start:b8,x:b3,y:b0,platform:Windows,


### PR DESCRIPTION
This is a micro-PR that fixes the source GitHub link in `gamecontrollerdb.txt`, as it hasn't been updated since this repository was moved to the *mdqinc* organisation.

GitHub still redirects the old link, so it's no major issue, but I figured it'd be best to update it.